### PR TITLE
Allow http/https urls in public key path

### DIFF
--- a/scripts/sign_key
+++ b/scripts/sign_key
@@ -8,12 +8,7 @@ user's private key to get access to servers that trust the CA.
 
 The final output of this script is an S3 URL containing the user's signed
 certificate. The user needs to take this URL and download the file it points
-at. The downloaded file should be named exactly like their private SSH key but
-with the suffix "-cert.pub".
-
-For example, if the user's key is ~/.ssh/id_rsa they should do something like
-
-    curl <THE URL> > ~/.ssh/id_rsa-cert.pub
+at.  This URL should be used with the get_cert script.
 
 """
 
@@ -22,11 +17,27 @@ import ConfigParser
 import os
 import sys
 import tempfile
+import urlparse
+import urllib
 
 from contextlib import closing
 
 import ssh_ca
 import ssh_ca.s3
+
+def get_public_key(path_or_url):
+    parsed = urlparse.urlparse(path_or_url)
+    fd = None
+    try:
+        if parsed.scheme in ('http', 'https'):
+            fd = urllib.urlopen(path_or_url)
+        else:
+            fd = open(path_or_url)
+        key_contents = fd.readline()
+    finally:
+        if fd:
+            fd.close()
+    return key_contents
 
 
 if __name__ == '__main__':
@@ -34,7 +45,7 @@ if __name__ == '__main__':
     default_config = os.path.expanduser(
         os.getenv('SSH_CA_CONFIG', '~/.ssh_ca/config'))
 
-    parser = argparse.ArgumentParser(__doc__)
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-a', '--authority',
         dest='authority', default=default_authority,
         help='Pick one: s3',
@@ -55,8 +66,9 @@ if __name__ == '__main__':
     )
     parser.add_argument('-p',
         dest='public_path',
-        help='Path to public key. If set we try to upload this. '
-             'Otherwise we try to download one.',
+        help='Path to public key. May be a local file or one located at a '
+             'http/https url. If set we try to upload this. Otherwise we try '
+             'to download one.',
     )
     parser.add_argument('-u',
         required=True, dest='username',
@@ -108,7 +120,8 @@ if __name__ == '__main__':
         if not public_path:
             print 'Upload needs a public key specified.'
             sys.exit(1)
-        ca.upload_public_key(username, public_path)
+        key_contents = get_public_key(public_path)
+        ca.upload_public_key(username, key_contents)
         print 'Public key %s for username %s uploaded.' % (public_path,
                                                            username)
         sys.exit(0)

--- a/ssh_ca/s3.py
+++ b/ssh_ca/s3.py
@@ -56,9 +56,9 @@ class S3Authority(ssh_ca.Authority):
         else:
             return None
 
-    def upload_public_key(self, username, key_file):
+    def upload_public_key(self, username, key_contents):
         k = self.ssh_bucket.new_key('keys/%s' % (username,))
-        k.set_contents_from_filename(key_file, replace=True)
+        k.set_contents_from_string(key_contents, replace=True)
 
     def upload_public_key_cert(self, username, cert_contents):
         k = self.ssh_bucket.new_key('certs/%s-cert.pub' % (username,))


### PR DESCRIPTION
This is made more useful by things like this:

https://github.com/phobologic.keys

So people wouldn't have to email/IM their keys, they could be grabbed
semi-automatically.

Not sure I'm super into this implementation, so I'd love a few more eyes on it.
