### PR TITLE
Generate a useful error when we can't download the cert from S3

### DIFF
--- a/scripts/get_cert
+++ b/scripts/get_cert
@@ -23,6 +23,11 @@ class CertMetadata(object):
 
 def download_cert_to_tempfile(url):
     resp = urllib.urlopen(url)
+    if resp.code > 299 or resp.code < 200:
+        print "Bad response code: HTTP/%d" % (resp.code,)
+        print resp.read()
+        sys.exit(1)
+
     temp_file = tempfile.NamedTemporaryFile(delete=False)
     with temp_file.file:
         temp_file.write(resp.read())
@@ -34,8 +39,7 @@ def get_cert_metadata(cert_path):
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if proc.stderr.read().find('is not a public key'):
-        print "Error processing signed cert from AWS:"
-        print open(cert_path).read()
+        print "Invalid signed ssh certificate file: %s" % (cert_path,)
         sys.exit(1)
 
     metadata = CertMetadata()


### PR DESCRIPTION
Right now when you try to download an expired cert, you get an ugly TypeError exception which hides the true cause of the problem.
