### PR TITLE
Bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 0.3.1
+tag = True
+commit = True
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:ssh_ca/__init__.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,9 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 tag = True
 commit = True
 
 [bumpversion:file:setup.py]
 
 [bumpversion:file:ssh_ca/__init__.py]
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='ssh-ca',
-    version='0.3.1',
+    version='0.3.2',
     description="SSH CA utilities",
     author="Bob Van Zant",
     author_email="bob@veznat.com",

--- a/ssh_ca/__init__.py
+++ b/ssh_ca/__init__.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 
 class SSHCAException(Exception):


### PR DESCRIPTION
Just testing it to see how it works - basically to increment the versions in setup.py and ssh_ca/__init__.py, as well as tag and commit the changes, you just run:

```
bumpversion [type]
```
so:

```
bumpversion patch # Results in 0.3.1 -> 0.3.2
bumpversion minor # Results in 0.3.1 -> 0.4.0
bumpversion patch # Results in 0.3.1 -> 1.0.0
```

What do you think?