### PR TITLE
os.rename doesn't work across devices

### DIFF
--- a/scripts/get_cert
+++ b/scripts/get_cert
@@ -7,6 +7,7 @@ next to that one.
 """
 import datetime
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -76,7 +77,7 @@ def find_private_key_for_public_key(pub_fingerprint):
 
 def move_cert_into_place(cert_path, private_key_filename):
     new_cert_filename = private_key_filename + '-cert.pub'
-    os.rename(cert_path, new_cert_filename)
+    shutil.move(cert_path, new_cert_filename)
 
 
 def re_add_identity(private_key_filename, valid_for_seconds):


### PR DESCRIPTION
This caused an issue for one of my coworkers who has `/home` mounted on
it's own device.